### PR TITLE
Change Testing MFCC's arguments

### DIFF
--- a/DTW_MFCC_KNN.ipynb
+++ b/DTW_MFCC_KNN.ipynb
@@ -271,7 +271,7 @@
    "outputs": [],
    "source": [
     "y, sr = librosa.load('test/farw0-b1-t.wav')\n",
-    "mfcc = librosa.feature.mfcc(y1, sr1)\n",
+    "mfcc = librosa.feature.mfcc(y, sr)\n",
     "distanceTest = []\n",
     "for i in range(len(files)):\n",
     "    y1, sr1 = librosa.load(dirname+\"/\"+files[i])\n",


### PR DESCRIPTION
For correct testing, loaded test file should be used for 1st MFCC function:
`y, sr` in place of `y1, sr1`